### PR TITLE
Remove the jungle inferno weapons from getUncraftableWeaponsForTrading()

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1863,7 +1863,7 @@ class Schema {
      */
     getUncraftableWeaponsForTrading() {
         return this.getCraftableWeaponsSchema()
-            .filter(item => ![348, 349].includes(item.defindex))
+            .filter(item => ![348, 349, 1178, 1179, 1180, 1181, 1190].includes(item.defindex))
             .map(item => `${item.defindex};6;uncraftable`);
     }
 


### PR DESCRIPTION
The weapons from jungle inferno are always craftable so they shouldn't be returned from `getUncraftableWeaponsForTrading()`