### PR TITLE
Fixed haunted mist and sizzling aroma effects

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -728,7 +728,7 @@ class Schema {
                 // Skip Frostbite effect if name include Faunted Braken
                 continue;
             }
-            if (effect === 'sizzling' && name.startsWith('aroma')) {
+            if (effect === 'sizzling' && name.startsWith('sizzling aroma')) {
                 continue;
             }
             if (effect === 'hot') {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -607,7 +607,8 @@ class Schema {
             'haunted kraken',
             'haunted forever!',
             'haunted cremation',
-            'haunted wick'
+            'haunted wick',
+            'haunted mist'
         ];
 
         let qualitySearch = name;
@@ -727,7 +728,9 @@ class Schema {
                 // Skip Frostbite effect if name include Faunted Braken
                 continue;
             }
-
+            if (effect === 'sizzling' && name.startsWith('aroma')) {
+                continue;
+            }
             if (effect === 'hot') {
                 // shotgun   ___     /  shot to hell
                 // plaid potshotter  /  shot in the dark


### PR DESCRIPTION
1. Fixed `sizzling` being matched first during `sizzling aroma`, causing `aroma` to be skipped due to `sizzling` already being a known effect.
2. Fixed `haunted mist` being incorrectly matched against `haunted` quality.

Issue
<img width="578" height="121" alt="image" src="https://github.com/user-attachments/assets/a76dfd14-09f0-4a0e-9ebc-7f5838a57963" />

Fix
<img width="568" height="121" alt="image" src="https://github.com/user-attachments/assets/197e9a4f-eeaf-43ec-8270-d59abd2962f4" />

